### PR TITLE
Cleaning Up time.py

### DIFF
--- a/module/time.py
+++ b/module/time.py
@@ -10,7 +10,7 @@ class Time:
     def __init__(self, bot):
         self.bot = bot
     
-    async def returnTime(self, ctx, us: str, time, name, aliases):
+    async def returnTime(self, ctx, us: str, time: datetime, name, aliases = []):
         aliases = '/'.join([name] + aliases).upper()
         if us == 'us':
             embed = discord.Embed(title='Time - ' + aliases + ' - US Format',
@@ -36,92 +36,32 @@ class Time:
     @time.command(name='cet', aliases=['cest'])
     async def cet(self, ctx, us: str = None):
         """Displays the current time in CET."""
-        time = datetime.now(tz=pytz.timezone('CET'))
-        if us == 'us':
-            embed = discord.Embed(title='Time - CET/CEST - US Format',
-                                  description=datetime.strftime(time, "%m/%d/%Y, %I:%M:%S %p"), colour=0x7f0000)
-            embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
-            await ctx.send(content=None, embed=embed)
-            return
-        embed = discord.Embed(title='Time - CET/CEST', description=datetime.strftime(time, "%d.%m.%Y, %H:%M:%S"),
-                              colour=0x7f0000)
-        embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
-        await ctx.send(content=None, embed=embed)
+        await self.returnTime(ctx, us, datetime.now(tz=pytz.timezone('CET')), 'cet', ['cest'])
 
     @time.command(name='gmt')
     async def gmt(self, ctx, us: str = None):
         """Displays the current time in GMT."""
-        time = datetime.now(tz=pytz.timezone('GMT'))
-        if us == 'us':
-            embed = discord.Embed(title='Time - GMT - US Format',
-                                  description=datetime.strftime(time, "%m/%d/%Y, %I:%M:%S %p"), colour=0x7f0000)
-            embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
-            await ctx.send(content=None, embed=embed)
-            return
-        embed = discord.Embed(title='Time - GMT', description=datetime.strftime(time, "%d.%m.%Y, %H:%M:%S"),
-                              colour=0x7f0000)
-        embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
-        await ctx.send(content=None, embed=embed)
+        await self.returnTime(ctx, us, datetime.now(tz=pytz.timezone('GMT')), 'gmt')
 
     @time.command(name='mst', aliases=['mdt'])
     async def mst(self, ctx, us: str = None):
         """Displays the current time in MST."""
-        time = datetime.now(tz=pytz.timezone('MST7MDT'))
-        if us == 'us':
-            embed = discord.Embed(title='Time - MST/MDT - US Format',
-                                  description=datetime.strftime(time, "%m/%d/%Y, %I:%M:%S %p"), colour=0x7f0000)
-            embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
-            await ctx.send(content=None, embed=embed)
-            return
-        embed = discord.Embed(title='Time - MST/MDT', description=datetime.strftime(time, "%d.%m.%Y, %H:%M:%S"),
-                              colour=0x7f0000)
-        embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
-        await ctx.send(content=None, embed=embed)
+        await self.returnTime(ctx, us, datetime.now(tz=pytz.timezone('MST7MDT')), 'mst', ['mdt'])
 
     @time.command(name='pst', aliases=['pdt'])
     async def pst(self, ctx, us: str = None):
         """Displays the current time in PST."""
-        time = datetime.now(tz=pytz.timezone('PST8PDT'))
-        if us == 'us':
-            embed = discord.Embed(title='Time - PST/PDT - US Format',
-                                  description=datetime.strftime(time, "%m/%d/%Y, %I:%M:%S %p"), colour=0x7f0000)
-            embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
-            await ctx.send(content=None, embed=embed)
-            return
-        embed = discord.Embed(title='Time - PST/PDT', description=datetime.strftime(time, "%d.%m.%Y, %H:%M:%S"),
-                              colour=0x7f0000)
-        embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
-        await ctx.send(content=None, embed=embed)
+        await self.returnTime(ctx, us, datetime.now(tz=pytz.timezone('PST8PDT')), 'pst', ['pdt'])
 
     @time.command(name='utc')
     async def utc(self, ctx, us: str = None):
         """Displays the current time in UTC."""
-        time = datetime.utcnow()
-        if us == 'us':
-            embed = discord.Embed(title='Time - UTC - US Format',
-                                  description=datetime.strftime(time, "%m/%d/%Y, %I:%M:%S %p"), colour=0x7f0000)
-            embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
-            await ctx.send(content=None, embed=embed)
-            return
-        embed = discord.Embed(title='Time - UTC ', description=datetime.strftime(time, "%d.%m.%Y, %H:%M:%S"),
-                              colour=0x7f0000)
-        embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
-        await ctx.send(content=None, embed=embed)
+        await self.returnTime(ctx, us, datetime.utcnow(), 'utc')
 
     @time.command(name='cst', aliases=['cdt'])
     async def cst(self, ctx, us: str = None):
         """Displays the current time in CST."""
-        time = datetime.now(tz=pytz.timezone('CST6CDT'))
-        if us == 'us':
-            embed = discord.Embed(title='Time - CST/CDT - US Format',
-                                  description=datetime.strftime(time, "%m/%d/%Y, %I:%M:%S %p"), colour=0x7f0000)
-            embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
-            await ctx.send(content=None, embed=embed)
-            return
-        embed = discord.Embed(title='Time - CST/CDT', description=datetime.strftime(time, "%d.%m.%Y, %H:%M:%S"),
-                              colour=0x7f0000)
-        embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
-        await ctx.send(content=None, embed=embed)
+        await self.returnTime(ctx, us, datetime.now(tz=pytz.timezone('CST6CDT')), 'cst', ['cdt'])
 
 
 def setup(bot):

--- a/module/time.py
+++ b/module/time.py
@@ -9,6 +9,19 @@ from discord.ext import commands
 class Time:
     def __init__(self, bot):
         self.bot = bot
+    
+    async def returnTime(self, ctx, us: str, time, name, aliases):
+        aliases = '/'.join([name] + aliases).upper()
+        if us == 'us':
+            embed = discord.Embed(title='Time - ' + aliases + ' - US Format',
+                                  description=datetime.strftime(time, "%m/%d/%Y, %I:%M:%S %p"), colour=0x7f0000)
+            embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
+            await ctx.send(content=None, embed=embed)
+            return
+        embed = discord.Embed(title='Time - ' + aliases, description=datetime.strftime(time, "%d.%m.%Y, %H:%M:%S"),
+                              colour=0x7f0000)
+        embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
+        await ctx.send(content=None, embed=embed)
 
     @commands.group(name='time')
     @commands.cooldown(1, config.getCooldown(), commands.BucketType.user)
@@ -18,17 +31,7 @@ class Time:
     @time.command(name='est', aliases=['edt'])
     async def est(self, ctx, us: str = None):
         """Displays the current time in EST."""
-        time = datetime.now(tz=pytz.timezone('EST5EDT'))
-        if us == 'us':
-            embed = discord.Embed(title='Time - EST/EDT - US Format',
-                                  description=datetime.strftime(time, "%m/%d/%Y, %I:%M:%S %p"), colour=0x7f0000)
-            embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
-            await ctx.send(content=None, embed=embed)
-            return
-        embed = discord.Embed(title='Time - EST/EDT', description=datetime.strftime(time, "%d.%m.%Y, %H:%M:%S"),
-                              colour=0x7f0000)
-        embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
-        await ctx.send(content=None, embed=embed)
+        await self.returnTime(ctx, us, datetime.now(tz=pytz.timezone('EST5EDT')), 'est', ['edt'])
 
     @time.command(name='cet', aliases=['cest'])
     async def cet(self, ctx, us: str = None):

--- a/module/time.py
+++ b/module/time.py
@@ -11,7 +11,8 @@ class Time:
         self.bot = bot
     
     async def returnTime(self, ctx, us: str, time: datetime, name, aliases = []):
-        aliases = '/'.join([name] + aliases).upper()
+        """Displays the current time in based on the inputted values."""
+        aliases = '/'.join([name] + aliases).upper() # Turns the list of aliases into a formatted string
         if us == 'us':
             embed = discord.Embed(title='Time - ' + aliases + ' - US Format',
                                   description=datetime.strftime(time, "%m/%d/%Y, %I:%M:%S %p"), colour=0x7f0000)


### PR DESCRIPTION
I added the Time.returnTime() function to help reduce bloat in time.py. All of the existing time commands are now using Time.returnTime(). Hopefully it also helps make adding new time zones quicker by reducing the amount of code.

I will admit that it isnt the most elegant though (`self.returnTime(ctx, us, datetime.now(tz=pytz.timezone('EST5EDT')), 'est', ['edt'])` being an example call).

It may be worth it to force keywords (`async def returnTime(self, ctx, us: str, *, time: datetime, name, aliases = [])`) to force clarity (`self.returnTime(ctx, us, time=datetime.now(tz=pytz.timezone('CET')), name='cet', aliases=['cest'])`), however I decided not to add it since it is purely optional.

The name of the function is also a little odd, however `Time.printTime()` didnt quite seem right either and I couldnt think of anything better. Also, the async may be a little wonkey since I havent used it before, however I am hoping it is fine since it is mostly copy paste and nothing seemed to go wrong in my tests.

Lastly, I am not sure if the new version is any more/less intensive of the server.