### PR TITLE
Possible Fix for Bot Not Taking Commands

### DIFF
--- a/client.py
+++ b/client.py
@@ -102,9 +102,7 @@ async def twitch_task():
                 if config.getTwitch()['everyonePingOnAnnouncement']:
                     await channel.send(f'@everyone {streamer} is live on Twitch!')
                 await channel.send(embed=embed)
-                await asyncio.sleep(30)
-            else:
-                await asyncio.sleep(30)
+        await asyncio.sleep(30)
 
 
 @client.event


### PR DESCRIPTION
From my brief tests this change seems to fix the bot not taking commands when Twitch announcements are on, however I was not able to fully test it due to my lack of a Twitch API key.