### PR TITLE
"Fix" #8 (Add Aliases)

### DIFF
--- a/config.py
+++ b/config.py
@@ -81,8 +81,8 @@ def getParties():
     return config_parties['parties']
 
 
-def getCapwordParties():
-    return config_parties['capwordParties']
+def getPartyAliases():
+    return config_parties['aliases']
 
 
 def getReddit():
@@ -112,14 +112,14 @@ async def addParty(guild, invite, party: str):
 
     capsParty = string.capwords(party)
     # If the party already ready exists, return False
-    if capsParty in config_parties['parties'] or capsParty in config_parties['capwordParties']:
+    if capsParty in config_parties['parties'] or capsParty in config_parties['aliases']:
         return False
     # Otherwise, create the party
     else:
         if capsParty == party:
             config_parties['parties'][capsParty] = invite
         else:
-            config_parties['capwordParties'][capsParty] = party
+            config_parties['aliases'][capsParty] = party
             config_parties['parties'][party] = invite
 
         dumpConfigParties()
@@ -132,7 +132,7 @@ async def deleteParty(guild, party: str):
 
     capsParty = string.capwords(party)
     # If the party already exists, delete it
-    if capsParty in config_parties['parties'] or capsParty in config_parties['capwordParties']:
+    if capsParty in config_parties['parties'] or capsParty in config_parties['aliases']:
         if capsParty in config_parties['parties']:
             role = discord.utils.get(guild.roles, name=capsParty)
             # If the party has a role, delete the role
@@ -140,13 +140,13 @@ async def deleteParty(guild, party: str):
                 await role.delete()
 
             del config_parties['parties'][capsParty]
-        elif capsParty in config_parties['capwordParties']:
-            role = discord.utils.get(guild.roles, name=config_parties['capwordParties'][capsParty])
+        elif capsParty in config_parties['aliases']:
+            role = discord.utils.get(guild.roles, name=config_parties['aliases'][capsParty])
             if role is not None:
                 await role.delete()
 
-            del config_parties['parties'][config_parties['capwordParties'][capsParty]]
-            del config_parties['capwordParties'][capsParty]
+            del config_parties['parties'][config_parties['aliases'][capsParty]]
+            del config_parties['aliases'][capsParty]
 
         dumpConfigParties()
     # Otherwise return False

--- a/config.py
+++ b/config.py
@@ -172,5 +172,20 @@ async def addPartyAlias(party: str, alias: str) -> str:
     return ''
 
 
+async def deletePartyAlias(alias: str) -> str:
+    """Deletes a party alias, returns an empty string if it was successfully deleted, otherwise returns error as string."""
+    capsAlias = string.capwords(alias)
+    if capsAlias not in config_parties['aliases']:
+        return f'{alias} not found!'
+    # Check if alias is a party name
+    elif string.capwords(config_parties['aliases'][capsAlias]) == capsAlias:
+        return 'May not delete party name!'
+    else:
+        del config_parties['aliases'][capsAlias]
+        dumpConfigParties()
+    
+    return ''
+
+
 if __name__ == '__main__':
     pass

--- a/config.py
+++ b/config.py
@@ -107,13 +107,14 @@ def dumpConfigParties():
         json.dump(config_parties, myfile, indent=2)
 
 
-async def addParty(guild, invite, party: str):
-    """Adds the inputted party paired with the invite, returns if the party was successfully added"""
+async def addParty(guild, invite, party: str) -> str:
+    """Adds the inputted party paired with the invite, returns an empty string if it was successfully added, otherwise returns error as string."""
 
     capsParty = string.capwords(party)
-    # If the party already ready exists, return False
-    if capsParty in config_parties['parties'] or capsParty in config_parties['aliases']:
-        return False
+    if capsParty in config_parties['parties']:
+        return f'{capsParty} already exists!'
+    elif capsParty in config_parties['aliases']:
+        return f'{capsParty} is already an alias!'
     # Otherwise, create the party
     else:
         if capsParty == party:
@@ -124,35 +125,39 @@ async def addParty(guild, invite, party: str):
 
         dumpConfigParties()
         await guild.create_role(name=party)
-    return True
+    return ''
 
 
-async def deleteParty(guild, party: str):
-    """Deletes the inputted party, returns if the party was successfully deleted"""
+async def deleteParty(guild, party: str) -> str:
+    """Deletes the inputted party, returns an empty string if it was successfully deleted, otherwise returns error as string."""
 
-    capsParty = string.capwords(party)
+    party = string.capwords(party)
+
+    # If the given party name is actually an alias, return an error
+    if party in config_parties['aliases'] and string.capwords(config_parties['aliases'][party]) != party:
+        return f'May not delete an alias! See `-deletealias`.'
     # If the party already exists, delete it
-    if capsParty in config_parties['parties'] or capsParty in config_parties['aliases']:
-        if capsParty in config_parties['parties']:
-            role = discord.utils.get(guild.roles, name=capsParty)
+    if party in config_parties['parties'] or party in config_parties['aliases']:
+        if party in config_parties['parties']:
+            role = discord.utils.get(guild.roles, name=party)
             # If the party has a role, delete the role
             if role is not None:
                 await role.delete()
 
-            del config_parties['parties'][capsParty]
-        elif capsParty in config_parties['aliases']:
-            role = discord.utils.get(guild.roles, name=config_parties['aliases'][capsParty])
+            del config_parties['parties'][party]
+        elif party in config_parties['aliases']:
+            role = discord.utils.get(guild.roles, name=config_parties['aliases'][party])
             if role is not None:
                 await role.delete()
 
-            del config_parties['parties'][config_parties['aliases'][capsParty]]
-            del config_parties['aliases'][capsParty]
+            del config_parties['parties'][config_parties['aliases'][party]]
+            del config_parties['aliases'][party]
 
         dumpConfigParties()
     # Otherwise return False
     else:
-        return False
-    return True
+        return f'{party} not found!'
+    return ''
 
 
 async def addPartyAlias(party: str, alias: str) -> str:

--- a/config.py
+++ b/config.py
@@ -129,29 +129,34 @@ async def addParty(guild, invite, party: str) -> str:
 
 
 async def deleteParty(guild, party: str) -> str:
-    """Deletes the inputted party, returns an empty string if it was successfully deleted, otherwise returns error as string."""
+    """Deletes the inputted party and related aliases, returns an empty string if it was successfully deleted, otherwise returns error as string."""
 
-    party = string.capwords(party)
+    capsParty = string.capwords(party)
 
     # If the given party name is actually an alias, return an error
-    if party in config_parties['aliases'] and string.capwords(config_parties['aliases'][party]) != party:
+    if capsParty in config_parties['aliases'] and string.capwords(config_parties['aliases'][capsParty]) != capsParty:
         return f'May not delete an alias! See `-deletealias`.'
     # If the party already exists, delete it
-    if party in config_parties['parties'] or party in config_parties['aliases']:
-        if party in config_parties['parties']:
+    if capsParty in config_parties['parties'] or capsParty in config_parties['aliases']:
+        if capsParty in config_parties['parties']:
             role = discord.utils.get(guild.roles, name=party)
             # If the party has a role, delete the role
             if role is not None:
                 await role.delete()
 
-            del config_parties['parties'][party]
-        elif party in config_parties['aliases']:
-            role = discord.utils.get(guild.roles, name=config_parties['aliases'][party])
+            del config_parties['parties'][capsParty]
+        elif capsParty in config_parties['aliases']:
+            role = discord.utils.get(guild.roles, name=config_parties['aliases'][capsParty])
             if role is not None:
                 await role.delete()
 
-            del config_parties['parties'][config_parties['aliases'][party]]
-            del config_parties['aliases'][party]
+            del config_parties['parties'][config_parties['aliases'][capsParty]]
+            del config_parties['aliases'][capsParty]
+        
+        # Delete related aliases
+        for alias in list(config_parties['aliases']):
+            if config_parties['aliases'][alias] == party and alias != capsParty:
+               del config_parties['aliases'][alias]
 
         dumpConfigParties()
     # Otherwise return False

--- a/config.py
+++ b/config.py
@@ -109,6 +109,8 @@ def dumpConfigParties():
 
 async def addParty(guild, invite, party: str) -> str:
     """Adds the inputted party paired with the invite, returns an empty string if it was successfully added, otherwise returns error as string."""
+    if ',' in party:
+        return f'May not have \',\' in party name!'
 
     capsParty = string.capwords(party)
     if capsParty in config_parties['parties']:

--- a/config.py
+++ b/config.py
@@ -155,5 +155,22 @@ async def deleteParty(guild, party: str):
     return True
 
 
+async def addPartyAlias(party: str, alias: str) -> str:
+    """Added alias as a new alias to party, returns an empty string if it was successfully added, otherwise returns error as string."""
+    capsAlias = string.capwords(alias)
+    if party not in config_parties['parties'] and string.capwords(party) not in config_parties['aliases']:
+        return f'{party} not found!'
+    elif alias in config_parties['parties'] or capsAlias in config_parties['parties']:
+        return f'{alias} is already the name of a party!'
+    elif capsAlias in config_parties['aliases']:
+        party = config_parties['aliases'][capsAlias]
+        return f'{alias} is already an alias for {party}!'
+    else:
+        config_parties['aliases'][capsAlias] = party
+        dumpConfigParties()
+
+    return ''
+
+
 if __name__ == '__main__':
     pass

--- a/config.py
+++ b/config.py
@@ -157,15 +157,19 @@ async def deleteParty(guild, party: str):
 
 async def addPartyAlias(party: str, alias: str) -> str:
     """Added alias as a new alias to party, returns an empty string if it was successfully added, otherwise returns error as string."""
-    capsAlias = string.capwords(alias)
-    if party not in config_parties['parties'] and string.capwords(party) not in config_parties['aliases']:
+    capsAlias, party = string.capwords(alias), string.capwords(party)
+
+    if party not in config_parties['parties'] and party not in config_parties['aliases']:
         return f'{party} not found!'
     elif alias in config_parties['parties'] or capsAlias in config_parties['parties']:
-        return f'{alias} is already the name of a party!'
+        return f'{capsAlias} is already the name of a party!'
     elif capsAlias in config_parties['aliases']:
         party = config_parties['aliases'][capsAlias]
-        return f'{alias} is already an alias for {party}!'
+        return f'{capsAlias} is already an alias for {party}!'
     else:
+        # If party has unusual caps, fix caps
+        if party not in config_parties['parties']:
+            party = config_parties['aliases'][party]
         config_parties['aliases'][capsAlias] = party
         dumpConfigParties()
 

--- a/config/config_parties.json
+++ b/config/config_parties.json
@@ -11,7 +11,7 @@
     "TIRPON": "https://discord.gg/MSBjVkf",
     "Independent": ""
   },
-  "capwordParties": {
+  "aliases": {
     "Democracorp": "DemocraCorp",
     "Monarchist Party Of Norway": "Monarchist Party of Norway",
     "Wes\u2019s Party For A Pink Role": "Wes\u2019s Party for a Pink Role",

--- a/module/parties.py
+++ b/module/parties.py
@@ -15,9 +15,9 @@ class Party(commands.Cog, name='Political Parties'):
     def __init__(self, bot):
         self.bot = bot
     
-    def fixCapwords(self, party):
-        """Fixes party names with unusual caps"""
-        return config.getCapwordParties().get(party, party)
+    def getPartyFromAlias(self, alias: str):
+        """Gets party name from related alias, returns alias if it is not found"""
+        return config.getPartyAliases().get(alias, alias)
 
     @commands.command(name='join')
     @commands.cooldown(1, config.getCooldown(), commands.BucketType.user)
@@ -31,8 +31,7 @@ class Party(commands.Cog, name='Political Parties'):
 
         party = string.capwords(' '.join(party))
 
-        # Fix capwords
-        party = self.fixCapwords(party)
+        party = self.getPartyFromAlias(party)
 
         member = ctx.message.author
         role = discord.utils.get(ctx.guild.roles, name=party)
@@ -90,8 +89,7 @@ class Party(commands.Cog, name='Political Parties'):
         party = string.capwords(' '.join(party))
         partyKeys = (config.getParties().keys())
 
-        # Fix capwords
-        party = self.fixCapwords(party)
+        party = self.getPartyFromAlias(party)
 
         member = ctx.message.author
         role = discord.utils.get(ctx.guild.roles, name=party)
@@ -157,8 +155,7 @@ class Party(commands.Cog, name='Political Parties'):
         if list == 'list':
             party = string.capwords(' '.join(party))
 
-            # Fix capwords
-            party = self.fixCapwords(party)
+            party = self.getPartyFromAlias(party)
 
             role = discord.utils.get(dcivGuild.roles, name=party)
             msg = ''

--- a/module/parties.py
+++ b/module/parties.py
@@ -232,6 +232,35 @@ class Party(commands.Cog, name='Political Parties'):
         else:
             await ctx.send(f':white_check_mark: Deleted {alias}!')
     
+    @commands.command(name='listaliases', hidden=True)
+    @commands.cooldown(1, config.getCooldown(), commands.BucketType.user)
+    @commands.has_permissions(administrator=True)
+    async def listaliases(self, ctx, *party: str):
+        party = string.capwords(' '.join(party))
+        capsParty = party
+
+        parties, aliases = config.getParties(), config.getPartyAliases()
+        if party in parties:
+            pass
+        elif party in aliases:
+            party = aliases[party]
+            capsParty = string.capwords(party)
+        else:
+            await ctx.send(f':x: {party} not found!')
+            return
+
+        msg = ''
+        for alias in aliases:
+            if aliases[alias] == party and alias != capsParty:
+                msg += f'{alias}\n'
+
+        if msg:
+            embed = discord.Embed(title=f'Aliases of {party}', description=f'{msg}', colour=0x7f0000)
+            embed.set_footer(text=config.getConfig()['botName'], icon_url=config.getConfig()['botIconURL'])
+            await ctx.send(embed=embed)
+        else:
+            await ctx.send(f":x: No aliases found for {party}!")
+    
     async def getArguments(self, ctx, arguments: str, expectedArguments: int = -1):
         """Returns arguments split upon commas as a tuple of strings.
         If arguments does not equal expectedArguments or there are blank arguments, posts a discord message and returns None.

--- a/module/parties.py
+++ b/module/parties.py
@@ -202,7 +202,38 @@ class Party(commands.Cog, name='Political Parties'):
                 await ctx.send(f':white_check_mark: Deleted {party}!')
             else:
                 await ctx.send(f':x: Unable to delete {party}')
+    
+    @commands.command(name='addalias', hidden=True)
+    @commands.cooldown(1, config.getCooldown(), commands.BucketType.user)
+    @commands.has_permissions(administrator=True)
+    async def addalias(self, ctx, *partyAndAlias: str):
+        """Adds a new alias to party"""
+        partyAndAlias: tuple = await self.getArguments(ctx, ' '.join(partyAndAlias), 2)
+        if partyAndAlias is None:
+            return
+        party, alias = partyAndAlias
+        error = await config.addPartyAlias(party, alias)
 
+        if error:
+            await ctx.send(f':x: {error}')
+        else:
+            await ctx.send(f':white_check_mark: Added {alias} as an alias for {party}!')
+    
+    async def getArguments(self, ctx, arguments: str, expectedArguments: int = -1):
+        """Returns arguments split upon commas as a tuple of strings.
+        If arguments does not equal expectedArguments or there are blank arguments, posts a discord message and returns None.
+        If expectedArguments is -1, does not check for argument count."""
+        argumentCount = arguments.count(',') + 1
+        if expectedArguments != -1 and argumentCount != expectedArguments:
+            await ctx.send(f':x: Was given {argumentCount} arguments but expected {expectedArguments}!')
+            return None
+        
+        arguments = tuple(argument.strip() for argument in arguments.split(','))
+        if '' in arguments:
+            await ctx.send(f':x: Cannot accept blank arguments!')
+            return None
+
+        return arguments
 
 def setup(bot):
     bot.add_cog(Party(bot))

--- a/module/parties.py
+++ b/module/parties.py
@@ -179,12 +179,12 @@ class Party(commands.Cog, name='Political Parties'):
 
         else:
             party = ' '.join(party)
-            hasNewParty = await config.addParty(ctx.guild, invite, party)
+            error = await config.addParty(ctx.guild, invite, party)
             
-            if hasNewParty:
-                await ctx.send(f':white_check_mark: Added {party} with {invite}!')
+            if error:
+                await ctx.send(f':x: {error}')
             else:
-                await ctx.send(f':x: Unable to create {party}')
+                await ctx.send(f':white_check_mark: Added {party} with {invite}!')
 
     @commands.command(name='deleteparty', hidden=True)
     @commands.cooldown(1, config.getCooldown(), commands.BucketType.user)
@@ -196,12 +196,12 @@ class Party(commands.Cog, name='Political Parties'):
 
         else:
             party = ' '.join(party)
-            deletedParty = await config.deleteParty(ctx.guild, party)
+            error = await config.deleteParty(ctx.guild, party)
 
-            if deletedParty:
-                await ctx.send(f':white_check_mark: Deleted {party}!')
+            if error:
+                await ctx.send(f':x: {error}')
             else:
-                await ctx.send(f':x: Unable to delete {party}')
+                await ctx.send(f':white_check_mark: Deleted {party}!')
     
     @commands.command(name='addalias', hidden=True)
     @commands.cooldown(1, config.getCooldown(), commands.BucketType.user)
@@ -217,6 +217,10 @@ class Party(commands.Cog, name='Political Parties'):
         if error:
             await ctx.send(f':x: {error}')
         else:
+            # Get proper names
+            alias = string.capwords(alias)
+            party = config.getPartyAliases()[alias]
+
             await ctx.send(f':white_check_mark: Added {alias} as an alias for {party}!')
     
     @commands.command(name='deletealias', hidden=True)
@@ -230,12 +234,15 @@ class Party(commands.Cog, name='Political Parties'):
         if error:
             await ctx.send(f':x: {error}')
         else:
+            # Get proper name
+            alias = string.capwords(alias)
             await ctx.send(f':white_check_mark: Deleted {alias}!')
     
     @commands.command(name='listaliases', hidden=True)
     @commands.cooldown(1, config.getCooldown(), commands.BucketType.user)
     @commands.has_permissions(administrator=True)
     async def listaliases(self, ctx, *party: str):
+        """Lists the given parties aliases, if any exist"""
         party = string.capwords(' '.join(party))
         capsParty = party
 

--- a/module/parties.py
+++ b/module/parties.py
@@ -219,6 +219,19 @@ class Party(commands.Cog, name='Political Parties'):
         else:
             await ctx.send(f':white_check_mark: Added {alias} as an alias for {party}!')
     
+    @commands.command(name='deletealias', hidden=True)
+    @commands.cooldown(1, config.getCooldown(), commands.BucketType.user)
+    @commands.has_permissions(administrator=True)
+    async def deletealias(self, ctx, *alias: str):
+        """Deletes pre-existing alias"""
+        alias = ' '.join(alias)
+        error = await config.deletePartyAlias(alias)
+
+        if error:
+            await ctx.send(f':x: {error}')
+        else:
+            await ctx.send(f':white_check_mark: Deleted {alias}!')
+    
     async def getArguments(self, ctx, arguments: str, expectedArguments: int = -1):
         """Returns arguments split upon commas as a tuple of strings.
         If arguments does not equal expectedArguments or there are blank arguments, posts a discord message and returns None.


### PR DESCRIPTION
As stated in #8, aliases may help with accidentally calling parties by the wrong name.

There are some differences between my proposal and the current code, the most notable of which is the command name changes:

- `addpartyalias` -> `addalias`
- `deletepartyalias` -> `deletealias`
- `listpartyalias` -> `listaliases`

I removed the "party" from the names due to often times accidentally adding a space between "party" and "alias", leading to a new party being created which I then had to delete. `listpartyalias` was renamed to better fit with the other commands. Another change is that `deletealias` now only takes the alias instead of both the party name and the alias.

I also added the getArguments function to module.parties. While it is only used in addalias, I did it this way so that if we add flairs we can easily add comma separated faction name support. addParty and deleteParty were modified to delete all aliases related to the party and also have extra checks based around aliases.

One dilemma I ran into was how to handle error reporting in config functions. I didn't want config functions to send messages to the guild (Not sure why, it just didn't feel right), as such I had them return errors to the caller. However this contradicts the method used in getArguments, which sends the error message from the function itself. I wasn't entirely sure how to handle this. If you would like one method to be used both places, let me know and I will modify the functions.

If there are any other changes needed (Errors I didn't catch, spaghetti code, etc), let me know and I will change it.

If you would like to make the additions yourself (You stated in #8 that you may want to work on it) feel free.