### PR TITLE
Bugfix/large dice hang

### DIFF
--- a/dciv_bot/module/misc.py
+++ b/dciv_bot/module/misc.py
@@ -624,7 +624,7 @@ class Misc(commands.Cog, name="Miscellaneous"):
         # []: Make the special message system more robust and logical 
 
         # Roll dice in a separate thread to prevent blocking, ideally.
-
+        
         roll = await self.bot.loop.run_in_executor(None, self.roll_dices, dices)
 
         if roll is None:
@@ -680,6 +680,10 @@ class Misc(commands.Cog, name="Miscellaneous"):
         if special_message:
             msg = f"{msg}\n{special_message}"
 
+        if len(msg) > 2000:
+            await ctx.send("Sorry, result too large")
+            return
+        
         await ctx.send(msg)
 
 def setup(bot):

--- a/dciv_bot/module/misc.py
+++ b/dciv_bot/module/misc.py
@@ -609,7 +609,7 @@ class Misc(commands.Cog, name="Miscellaneous"):
             for dice in dice_pattern.dices:
                 if dice.sides > 100000 or dice.amount > 200:
                     # If they're not rolling a reasonable amount of dice, abort the roll. Nice job Piper...
-                    failure_message = f"{ctx.author.mention}, can't roll {dice.amount}d{dice.sides}, too many dice"
+                    failure_message = f"{ctx.author.mention}, can't roll `{dice.amount}d{dice.sides}`, too many dice"
                     await ctx.send(failure_message)
                     return
 

--- a/dciv_bot/module/misc.py
+++ b/dciv_bot/module/misc.py
@@ -607,7 +607,7 @@ class Misc(commands.Cog, name="Miscellaneous"):
 
             # Ensure the number of dice the user asked to roll is reasonable
             for dice in dice_pattern.dices:
-                if dice.sides > 1000000 or dice.amount > 200:
+                if dice.sides > 100000 or dice.amount > 200:
                     # If they're not rolling a reasonable amount of dice, abort the roll. Nice job Piper...
                     failure_message = f"{ctx.author.mention}, can't roll {dice.amount}d{dice.sides}, too many dice"
                     await ctx.send(failure_message)

--- a/dciv_bot/module/misc.py
+++ b/dciv_bot/module/misc.py
@@ -5,6 +5,7 @@ import discord
 import operator
 import datetime
 import xdice
+import re
 
 from dciv_bot.config import config
 from discord.ext import commands
@@ -602,6 +603,11 @@ class Misc(commands.Cog, name="Miscellaneous"):
 
         try:
             # Attempt to parse the user command
+            if re.match("[rR]\d*\(.*\)", dices):
+                failure_message = f"{ctx.author.mention}, repeat notation is disabled."
+                await ctx.send(failure_message)
+                return
+
             dice_pattern = xdice.Pattern(dices)
             dice_pattern.compile()
 

--- a/dciv_bot/module/misc.py
+++ b/dciv_bot/module/misc.py
@@ -601,9 +601,19 @@ class Misc(commands.Cog, name="Miscellaneous"):
         # []: Make the special message system more robust and logical 
 
         try:
-            # Attempt to parse the user command and roll the dice
+            # Attempt to parse the user command
             dice_pattern = xdice.Pattern(dices)
             dice_pattern.compile()
+
+            # Ensure the number of dice the user asked to roll is reasonable
+            for dice in dice_pattern.dices:
+                if dice.sides > 1000000 or dice.amount > 200:
+                    # If they're not rolling a reasonable amount of dice, abort the roll. Nice job Piper...
+                    failure_message = f"{ctx.author.mention}, can't roll {dice.amount}d{dice.sides}, too many dice"
+                    await ctx.send(failure_message)
+                    return
+
+            # Roll the dice
             roll = dice_pattern.roll()
         except (SyntaxError, TypeError, ValueError):
             raise commands.BadArgument()

--- a/dciv_bot/module/misc.py
+++ b/dciv_bot/module/misc.py
@@ -615,7 +615,7 @@ class Misc(commands.Cog, name="Miscellaneous"):
             for dice in dice_pattern.dices:
                 if dice.sides > 100000 or dice.amount > 200:
                     # If they're not rolling a reasonable amount of dice, abort the roll. Nice job Piper...
-                    failure_message = f"{ctx.author.mention}, can't roll {dice.amount}d{dice.sides}, too many dice"
+                    failure_message = f"{ctx.author.mention}, can't roll ~~{dice.amount}d{dice.sides}~~, too many dice"
                     await ctx.send(failure_message)
                     return
 


### PR DESCRIPTION
In the current version, rolling thousands of large dice will cause the bot to hang, such as the command `-roll 1000000d100000`. This PR will put a cap on the number of dice rolled to prevent abuse.