### PR TITLE
Give command suggestion on invalid command

### DIFF
--- a/dciv_bot/event/error_handler.py
+++ b/dciv_bot/event/error_handler.py
@@ -137,11 +137,13 @@ class ErrorHandler(commands.Cog):
 
         # Anything in ignored will return
         if isinstance(error, commands.CommandNotFound):
+            message = f":x: Could not find command `{ctx.invoked_with}`."
             if self.bot.commands:
                 async with ctx.typing():
                     shortest = min(*self.bot.commands, key=lambda cmd: levenshtein.distance(cmd.name, ctx.invoked_with))
-                    await ctx.send(f":x: Could not find command {ctx.invoked_with}. Did you mean {shortest.name}?")
+                    message += f"Did you mean `{shortest.name}`?"
             
+            await ctx.send(message)
             return
 
         elif isinstance(error, commands.MissingRequiredArgument):

--- a/dciv_bot/event/error_handler.py
+++ b/dciv_bot/event/error_handler.py
@@ -137,6 +137,9 @@ class ErrorHandler(commands.Cog):
 
         # Anything in ignored will return
         if isinstance(error, commands.CommandNotFound):
+            if await self.bot.cogs["Tags"].send_tag(ctx.message):
+                return
+
             message = f":x: There is no command called `{ctx.invoked_with}`."
             if self.bot.commands:
                 async with ctx.typing():

--- a/dciv_bot/event/error_handler.py
+++ b/dciv_bot/event/error_handler.py
@@ -137,15 +137,15 @@ class ErrorHandler(commands.Cog):
 
         # Anything in ignored will return
         if isinstance(error, commands.CommandNotFound):
-            message = f":x: Could not find command `{ctx.invoked_with}`."
+            message = f":x: There is no command called `{ctx.invoked_with}`."
             if self.bot.commands:
                 async with ctx.typing():
                     closest_alias = min(*self.bot.all_commands.keys(), key=lambda cmd: levenshtein.distance(cmd, ctx.invoked_with))
                     closest_name = self.bot.all_commands.get(closest_alias).name
                     if closest_alias == closest_name:
-                        message += f" Did you mean `{closest_alias}`?"
+                        message += f" Did you mean `{ctx.prefix}{closest_alias}`?"
                     else:
-                        message += f" Did you mean `{closest_alias}` (`{closest_name}`)?"
+                        message += f" Did you mean `{ctx.prefix}{closest_alias}`, an alias of the `{ctx.prefix}{closest_name}` command?"
             
             await ctx.send(message)
             return

--- a/dciv_bot/event/error_handler.py
+++ b/dciv_bot/event/error_handler.py
@@ -137,7 +137,7 @@ class ErrorHandler(commands.Cog):
 
         # Anything in ignored will return
         if isinstance(error, commands.CommandNotFound):
-            if await self.bot.cogs["Tags"].send_tag(ctx.message):
+            if self.bot.cogs.get("Tags") and await self.bot.cogs["Tags"].send_tag(ctx.message):
                 return
 
             message = f":x: There is no command called `{ctx.invoked_with}`."

--- a/dciv_bot/event/error_handler.py
+++ b/dciv_bot/event/error_handler.py
@@ -140,8 +140,12 @@ class ErrorHandler(commands.Cog):
             message = f":x: Could not find command `{ctx.invoked_with}`."
             if self.bot.commands:
                 async with ctx.typing():
-                    shortest = min(*self.bot.commands, key=lambda cmd: levenshtein.distance(cmd.name, ctx.invoked_with))
-                    message += f"Did you mean `{shortest.name}`?"
+                    closest_alias = min(*self.bot.all_commands.keys(), key=lambda cmd: levenshtein.distance(cmd, ctx.invoked_with))
+                    closest_name = self.bot.all_commands.get(closest_alias).name
+                    if closest_alias == closest_name:
+                        message += f" Did you mean `{closest_alias}`?"
+                    else:
+                        message += f" Did you mean `{closest_alias}` (`{closest_name}`)?"
             
             await ctx.send(message)
             return

--- a/dciv_bot/event/error_handler.py
+++ b/dciv_bot/event/error_handler.py
@@ -1,6 +1,7 @@
 import asyncio
 import traceback
 import dciv_bot.util.utils as utils
+import dciv_bot.util.levenshtein as levenshtein
 import dciv_bot.util.exceptions as exceptions
 
 from dciv_bot.util import mk
@@ -136,6 +137,11 @@ class ErrorHandler(commands.Cog):
 
         # Anything in ignored will return
         if isinstance(error, commands.CommandNotFound):
+            if self.bot.commands:
+                async with ctx.typing():
+                    shortest = min(*self.bot.commands, key=lambda cmd: levenshtein.distance(cmd.name, ctx.invoked_with))
+                    await ctx.send(f":x: Could not find command {ctx.invoked_with}. Did you mean {shortest.name}?")
+            
             return
 
         elif isinstance(error, commands.MissingRequiredArgument):

--- a/dciv_bot/module/tags.py
+++ b/dciv_bot/module/tags.py
@@ -585,16 +585,16 @@ class Tags(commands.Cog):
         await self.bot.db.execute("UPDATE guild_tags SET uses = uses + 1 WHERE id = $1", tag_id)
         return tag_details
 
-    @commands.Cog.listener(name="on_message")
-    async def guild_tags_listener(self, message):
+    async def send_tag(self, message):
+        """If the tag exists, the contents are sent. If the tag is exists returns True, otherwise returns False."""
         if not message.content.startswith(config.BOT_PREFIX):
-            return
+            return False
 
         if message.author.bot:
-            return
+            return False
 
         if (await self.bot.get_context(message)).valid:
-            return
+            return False
 
         tag_name = message.content[len(config.BOT_PREFIX):]
 
@@ -604,7 +604,7 @@ class Tags(commands.Cog):
                 tag_name.lower())
 
             if tag_id is None:
-                return
+                return False
 
             tag_details = await self.bot.db.fetchrow("SELECT * FROM guild_tags WHERE id = $1", tag_id)
 
@@ -612,7 +612,7 @@ class Tags(commands.Cog):
             tag_details = await self.resolve_tag_name(tag_name, message.guild)
 
         if tag_details is None:
-            return
+            return False
 
         tag_content_type = self.get_tag_content_type(tag_details['content'])
 
@@ -622,9 +622,11 @@ class Tags(commands.Cog):
                 embed.set_image(url=tag_details['content'])
 
                 try:
-                    return await message.channel.send(embed=embed)
+                    await message.channel.send(embed=embed)
+                    return True
                 except discord.HTTPException:
-                    return await message.channel.send(discord.utils.escape_mentions(tag_details['content']))
+                    await message.channel.send(discord.utils.escape_mentions(tag_details['content']))
+                    return True
 
             embed = self.bot.embeds.embed_builder(title=tag_details['title'], description=tag_details['content'],
                                                   has_footer=False)
@@ -632,6 +634,8 @@ class Tags(commands.Cog):
 
         else:
             await message.channel.send(discord.utils.escape_mentions(tag_details['content']))
+        
+        return True
 
 
 def setup(bot):

--- a/dciv_bot/module/tags.py
+++ b/dciv_bot/module/tags.py
@@ -587,15 +587,6 @@ class Tags(commands.Cog):
 
     async def send_tag(self, message):
         """If the tag exists, the contents are sent. If the tag is exists returns True, otherwise returns False."""
-        if not message.content.startswith(config.BOT_PREFIX):
-            return False
-
-        if message.author.bot:
-            return False
-
-        if (await self.bot.get_context(message)).valid:
-            return False
-
         tag_name = message.content[len(config.BOT_PREFIX):]
 
         if message.guild is None:

--- a/dciv_bot/util/levenshtein.py
+++ b/dciv_bot/util/levenshtein.py
@@ -1,23 +1,17 @@
 def distance(a, b):
-    distances = [[0 for _ in range(len(b)+1)] for _ in range(len(a)+1)]
+    previous_distances = list(range(len(b)+1))
+    current_distances = [0 for _ in range(len(b)+1)]
 
     for i in range(len(a)):
-        distances[i+1][0] = i+1
-    
-    for j in range(len(b)):
-        distances[0][j+1] = j+1
-    
-    for i in range(len(a)):
+        current_distances[0] = i + 1
+
         for j in range(len(b)):
-            distances[i+1][j+1] = min(
-                distances[i][j+1] + 1,
-                distances[i+1][j] + 1,
-                distances[i][j] + (0 if a[i] == b[j] else 1)
+            current_distances[j+1] = min(
+                previous_distances[j+1] + 1,
+                current_distances[j] + 1,
+                previous_distances[j] + (0 if a[i] == b[j] else 1)
             )
-    
-    return distances[-1][-1]
 
-# Temprorary, for performance testing
-if __name__ == "__main__":
-    import timeit
-    print(timeit.timeit(stmt="distance('foo', 'barrr')", number=1000, globals=globals()))
+        previous_distances, current_distances = current_distances, previous_distances
+    
+    return previous_distances[-1]

--- a/dciv_bot/util/levenshtein.py
+++ b/dciv_bot/util/levenshtein.py
@@ -1,0 +1,12 @@
+def distance(a, b):
+    return distance2(a, b, len(a), len(b))
+
+def distance2(a, b, i, j):
+    if min(i, j) == 0:
+        return max(i, j)
+    else:
+        return min(
+            distance2(a, b, i-1, j) + 1,
+            distance2(a, b, i, j-1) + 1,
+            distance2(a, b, i-1, j-1) + (1 if a[i-1] != b[j-1] else 0)
+        )

--- a/dciv_bot/util/levenshtein.py
+++ b/dciv_bot/util/levenshtein.py
@@ -1,12 +1,23 @@
 def distance(a, b):
-    return distance2(a, b, len(a), len(b))
+    distances = [[0 for _ in range(len(b)+1)] for _ in range(len(a)+1)]
 
-def distance2(a, b, i, j):
-    if min(i, j) == 0:
-        return max(i, j)
-    else:
-        return min(
-            distance2(a, b, i-1, j) + 1,
-            distance2(a, b, i, j-1) + 1,
-            distance2(a, b, i-1, j-1) + (1 if a[i-1] != b[j-1] else 0)
-        )
+    for i in range(len(a)):
+        distances[i+1][0] = i+1
+    
+    for j in range(len(b)):
+        distances[0][j+1] = j+1
+    
+    for i in range(len(a)):
+        for j in range(len(b)):
+            distances[i+1][j+1] = min(
+                distances[i][j+1] + 1,
+                distances[i+1][j] + 1,
+                distances[i][j] + (0 if a[i] == b[j] else 1)
+            )
+    
+    return distances[-1][-1]
+
+# Temprorary, for performance testing
+if __name__ == "__main__":
+    import timeit
+    print(timeit.timeit(stmt="distance('foo', 'barrr')", number=1000, globals=globals()))


### PR DESCRIPTION
This PR makes it so that when someone uses an invalid command, the bot suggests a similar command. It uses the Levenshtein distance between the inputted command and all valid commands, and responds with the one with the least distance. Due to how Python's `min` works, if two commands have equally low Levenshtein distances, then the one to appear first in the iterable is printed.

![levenshtein](https://user-images.githubusercontent.com/39784551/90324837-9df53480-df28-11ea-9ea7-400198a80f18.PNG)

There is no threshold in place, so it will respond even if the most similar command is very different:

![levenshtein2](https://user-images.githubusercontent.com/39784551/90324859-da289500-df28-11ea-94ae-b91278ceb7cf.PNG)

An issue is speed. The Levenshtein implementation is fast enough to function nicely right now, but if a lot more commands are added or some long ones are added, the performance could greatly suffer.

Another issue is that it will respond to all messages which start with a `-`, even if it is obvious to humans that it is not intended as a command. It must *start* with `-` so it is not too bad, but it could be problematic nontheless.